### PR TITLE
add vscode debugging configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 
 /.vscode/**/*
+!/.vscode/launch.json
 !/.vscode/extensions.json
 
 /node_modules

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,7 @@
 {
 	"recommendations": [
-		"dbaeumer.vscode-eslint"
+        "dbaeumer.vscode-eslint",
+        "msjsdiag.debugger-for-chrome",
+        "ritwickdey.liveserver",
 	]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "chrome",
+            "request": "launch",
+            "name": "Launch Chrome with Debugging",
+            "url": "http://localhost:5500",
+            "webRoot": "${workspaceFolder}",
+            "showAsyncStacks": true
+        }
+    ]
+}


### PR DESCRIPTION
This adds a few more recommended extensions for debugging chrome inside vscode, as well as adding the launch configuration to use the default port for the 'Live Server' extension.

The server needs to be started up with a button at the bottom 'Go Live' and after that, any changes of code will restart any open pages (preferably through debugging)

You should just be able to hit 'F5' to start debugging, after starting the live server.